### PR TITLE
Add embedded PNG export/import with transparent canvas

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,5 +3,9 @@ export default [
     ignores: ['node_modules/**'],
     files: ['**/*.js'],
     languageOptions: { ecmaVersion: 2021, sourceType: 'script' }
+  },
+  {
+    files: ['public/embed-png.js'],
+    languageOptions: { ecmaVersion: 2021, sourceType: 'module' }
   }
 ];

--- a/public/embed-png.js
+++ b/public/embed-png.js
@@ -1,0 +1,303 @@
+import extract from 'https://esm.sh/png-chunks-extract';
+import encode from 'https://esm.sh/png-chunks-encode';
+import { deflate, inflate } from 'https://esm.sh/pako@2.1.0';
+
+function makeITXt(keyword, textUint8, compressed = true) {
+  const k = new TextEncoder().encode(keyword);
+  const z = compressed ? deflate(textUint8) : textUint8;
+  const arr = [];
+  arr.push(...k, 0, compressed ? 1 : 0, 0, 0, 0, ...z);
+  return { name: 'iTXt', data: new Uint8Array(arr) };
+}
+
+function parseITXt(data) {
+  let i = 0;
+  while (i < data.length && data[i] !== 0) i++;
+  const keyword = new TextDecoder().decode(data.slice(0, i));
+  const compressed = data[i + 1] === 1;
+  let p = i + 5; // skip keyword, 0, compression, method, language (0)
+  while (p < data.length && data[p] !== 0) p++;
+  p++;
+  while (p < data.length && data[p] !== 0) p++;
+  p++;
+  const text = data.slice(p);
+  const textUint8 = compressed ? inflate(text) : text;
+  return { keyword, compressed, textUint8 };
+}
+
+async function renderPNGTransparentBlob() {
+  const cvs = window.cvs;
+  const DPR = window.DPR || 1;
+  const off = document.createElement('canvas');
+  off.width = cvs.width;
+  off.height = cvs.height;
+  const ox = off.getContext('2d');
+  ox.setTransform(DPR, 0, 0, DPR, 0, 0);
+  for (const s of window.strokes.values()) {
+    if (s.mode === 'image') {
+      if (s._img)
+        ox.drawImage(
+          s._img,
+          (s.x - window.camera.x) * window.camera.scale,
+          (s.y - window.camera.y) * window.camera.scale,
+          s.w * window.camera.scale,
+          s.h * window.camera.scale
+        );
+      continue;
+    }
+    ox.save();
+    ox.lineJoin = 'round';
+    ox.lineCap = 'round';
+    ox.globalCompositeOperation =
+      s.mode === 'erase' ? 'destination-out' : 'source-over';
+    ox.strokeStyle = s.color;
+    ox.lineWidth = s.size * window.camera.scale;
+    ox.beginPath();
+    s.points.forEach((p, i) => {
+      const x = (p.x - window.camera.x) * window.camera.scale;
+      const y = (p.y - window.camera.y) * window.camera.scale;
+      if (i === 0) ox.moveTo(x, y);
+      else ox.lineTo(x, y);
+    });
+    ox.stroke();
+    ox.restore();
+  }
+  return await new Promise((res) => off.toBlob(res, 'image/png'));
+}
+
+async function exportEmbeddedPNG() {
+  const blob = await renderPNGTransparentBlob();
+  const pngBuf = new Uint8Array(await blob.arrayBuffer());
+  const chunks = extract(pngBuf);
+  const state = window.serializeState();
+  const json = new TextEncoder().encode(JSON.stringify(state));
+  const itxt = makeITXt('rtcanvas', json, true);
+  const out = encode([
+    ...chunks.slice(0, -1),
+    itxt,
+    chunks[chunks.length - 1],
+  ]);
+  return new Blob([out], { type: 'image/png' });
+}
+
+function vectorizeImageToStrokes(imgCanvas, toWorld, sizeScale) {
+  const { width, height } = imgCanvas;
+  const ix = imgCanvas.getContext('2d').getImageData(0, 0, width, height);
+  const data = ix.data;
+  const quant = (v) => ((v / 16) | 0) * 16;
+  const out = [];
+  const MAX = 50000;
+  let stepY = 1;
+  let idn = 0;
+  while (true) {
+    out.length = 0;
+    for (let y = 0; y < height; y += stepY) {
+      let x = 0;
+      while (x < width) {
+        const i = (y * width + x) * 4;
+        const a = data[i + 3];
+        if (a < 8) {
+          x++;
+          continue;
+        }
+        const r = quant(data[i + 0]);
+        const g = quant(data[i + 1]);
+        const b = quant(data[i + 2]);
+        let x0 = x;
+        let x1 = x;
+        for (let xx = x + 1; xx < width; xx++) {
+          const j = (y * width + xx) * 4;
+          const aa = data[j + 3];
+          const rr = quant(data[j + 0]);
+          const gg = quant(data[j + 1]);
+          const bb = quant(data[j + 2]);
+          if (aa < 8 || rr !== r || gg !== g || bb !== b) break;
+          x1 = xx;
+        }
+        if (x1 > x0) {
+          const p0 = toWorld(x0, y);
+          const p1 = toWorld(x1, y);
+          out.push({
+            id: `imp-${Date.now()}-${idn++}`,
+            by: window.meId,
+            mode: 'draw',
+            color: `rgb(${r},${g},${b})`,
+            size: sizeScale,
+            points: [p0, p1],
+          });
+          if (out.length > MAX) break;
+        }
+        x = x1 + 1;
+      }
+      if (out.length > MAX) break;
+    }
+    if (out.length <= MAX || stepY > 8) break;
+    stepY *= 2;
+  }
+  return out;
+}
+
+let placement = null;
+let overlay = null;
+
+function updatePlacement() {
+  if (!placement) return;
+  const img = placement.img;
+  img.style.transform = `translate(${placement.x}px,${placement.y}px) scale(${placement.scale})`;
+}
+
+function cleanupPlacement() {
+  if (overlay) overlay.remove();
+  overlay = null;
+  placement = null;
+  window.requestRender();
+  document.removeEventListener('keydown', keyHandler);
+}
+
+function keyHandler(e) {
+  if (!placement) return;
+  if (e.key === 'Escape') {
+    cleanupPlacement();
+  } else if (e.key === 'Enter') {
+    finalizePlacement();
+  }
+}
+
+document.addEventListener('keydown', keyHandler);
+
+async function finalizePlacement() {
+  if (!placement) return;
+  const imgEl = placement.img;
+  let w = imgEl.naturalWidth;
+  let h = imgEl.naturalHeight;
+  let scaleImg = 1;
+  if (w > 2048) {
+    scaleImg = 2048 / w;
+    w = 2048;
+    h = Math.round(h * scaleImg);
+  }
+  const off = document.createElement('canvas');
+  off.width = w;
+  off.height = h;
+  off.getContext('2d').drawImage(imgEl, 0, 0, w, h);
+  const toWorld = (x, y) => {
+    const sx = placement.x + (x * placement.scale) / scaleImg;
+    const sy = placement.y + (y * placement.scale) / scaleImg;
+    return window.screenToWorld(sx, sy);
+  };
+  const sizeScale = (placement.scale / window.camera.scale) / scaleImg;
+  const strokes = vectorizeImageToStrokes(off, toWorld, sizeScale);
+  const added = window.mergeState({ strokes }, { setBg: false });
+  for (const id of added) {
+    window.myStack.push(id);
+    const s = window.strokes.get(id);
+    window.Net.sendReliable({ type: 'add', stroke: { ...s } });
+  }
+  cleanupPlacement();
+}
+
+async function startPlacement(imgBlob) {
+  const url = URL.createObjectURL(imgBlob);
+  const img = new Image();
+  await new Promise((res) => {
+    img.onload = res;
+    img.src = url;
+  });
+  placement = {
+    img,
+    x: (innerWidth - img.width) / 2,
+    y: (innerHeight - img.height) / 2,
+    scale: 1,
+  };
+  overlay = document.createElement('div');
+  overlay.style.position = 'fixed';
+  overlay.style.left = '0';
+  overlay.style.top = '0';
+  overlay.style.right = '0';
+  overlay.style.bottom = '0';
+  overlay.style.zIndex = '100';
+  overlay.style.cursor = 'move';
+  overlay.appendChild(img);
+  const panel = document.createElement('div');
+  panel.style.position = 'absolute';
+  panel.style.left = '50%';
+  panel.style.top = '10px';
+  panel.style.transform = 'translateX(-50%)';
+  panel.style.background = 'rgba(255,255,255,0.8)';
+  panel.style.border = '1px solid #ccc';
+  panel.style.borderRadius = '8px';
+  panel.style.padding = '6px';
+  panel.style.display = 'flex';
+  panel.style.gap = '8px';
+  const placeBtn = document.createElement('button');
+  placeBtn.textContent = 'Place';
+  const cancelBtn = document.createElement('button');
+  cancelBtn.textContent = 'Cancel';
+  panel.appendChild(placeBtn);
+  panel.appendChild(cancelBtn);
+  overlay.appendChild(panel);
+  document.body.appendChild(overlay);
+  updatePlacement();
+  let dragging = false;
+  let lx = 0;
+  let ly = 0;
+  overlay.addEventListener('pointerdown', (e) => {
+    dragging = true;
+    lx = e.clientX;
+    ly = e.clientY;
+  });
+  overlay.addEventListener('pointermove', (e) => {
+    if (!dragging) return;
+    placement.x += e.clientX - lx;
+    placement.y += e.clientY - ly;
+    lx = e.clientX;
+    ly = e.clientY;
+    updatePlacement();
+  });
+  overlay.addEventListener('pointerup', () => {
+    dragging = false;
+  });
+  overlay.addEventListener('pointerleave', () => {
+    dragging = false;
+  });
+  overlay.addEventListener(
+    'wheel',
+    (e) => {
+      e.preventDefault();
+      const ds = Math.exp(-e.deltaY / 500);
+      const cx = e.clientX;
+      const cy = e.clientY;
+      placement.scale *= ds;
+      placement.x = cx - (cx - placement.x) * ds;
+      placement.y = cy - (cy - placement.y) * ds;
+      updatePlacement();
+    },
+    { passive: false }
+  );
+  placeBtn.onclick = finalizePlacement;
+  cancelBtn.onclick = cleanupPlacement;
+}
+
+async function importPNG(fileOrBlob) {
+  const buf = new Uint8Array(await fileOrBlob.arrayBuffer());
+  const chunks = extract(buf);
+  const itxt = chunks.find((c) => c.name === 'iTXt');
+  if (itxt) {
+    const meta = parseITXt(itxt.data);
+    if (meta.keyword === 'rtcanvas') {
+      const json = new TextDecoder().decode(meta.textUint8);
+      const state = JSON.parse(json);
+      const added = window.mergeState(state, { setBg: false });
+      for (const id of added) {
+        window.myStack.push(id);
+        const s = window.strokes.get(id);
+        window.Net.sendReliable({ type: 'add', stroke: { ...s } });
+      }
+      return;
+    }
+  }
+  await startPlacement(fileOrBlob);
+}
+
+window.exportEmbeddedPNG = exportEmbeddedPNG;
+window.importPNG = importPNG;

--- a/public/index.html
+++ b/public/index.html
@@ -91,6 +91,7 @@
     <button id="undo" title="Отменить">↶</button>
     <button id="redo" title="Повторить">↷</button>
     <button id="export" title="Сохранить PNG">🖼️ PNG</button>
+    <button id="import" title="Импорт PNG">📥 Import</button>
     <button id="settingsBtn" title="Настройки">⚙️</button>
   </div>
 </div>
@@ -116,6 +117,7 @@
   <div class="row"><button id="settingsClose">Закрыть</button></div>
 </div>
 
+<script type="module" src="embed-png.js"></script>
 <script src="net-webrtc.js"></script>
 <script>
 // ===== util =====
@@ -215,31 +217,26 @@ $('#bg').oninput = e=> { bgColor=e.target.value; requestRender(); debounceSave()
 $('#gridColor').oninput = e=> { gridColor=e.target.value; drawGrid(); };
 $('#undo').onclick = undo; $('#redo').onclick = redo;
 $('#export').onclick = exportPNG;
+$('#import').onclick = ()=> imageLoader.click();
 $('#settingsBtn').onclick = ()=>{ $('#settings').style.display='block'; $$('.hk').forEach(inp=> inp.value=hotkeys[inp.dataset.action]||''); $('#cursorColorInput').value=cursorColor; };
 $('#settingsClose').onclick = ()=>{ $('#settings').style.display='none'; saveSettings(); renderHint(); };
 $$('.hk').forEach(inp=>{ inp.oninput=()=>{ hotkeys[inp.dataset.action]=inp.value; saveSettings(); renderHint(); }; });
 $('#cursorColorInput').oninput = e=>{ cursorColor=e.target.value; updateSelPattern(); saveSettings(); requestRender(); };
-imageLoader.onchange = e=>{
+imageLoader.onchange = async e=>{
   const file=e.target.files[0];
-  if(!file) return;
-  const reader=new FileReader();
-  reader.onload=ev=>{
-    const img=new Image();
-    img.onload=()=>{
-      const pos=screenToWorld(innerWidth/2,innerHeight/2);
-      const id=genId();
-      const s={id,by:meId,mode:'image',x:pos.x,y:pos.y,w:img.width,h:img.height,data:ev.target.result};
-      loadImageForStroke(s);
-      strokes.set(id,s); cache.set(id,s); myStack.push(id); redoStack.length=0;
-      const payload={...s};
-      Net.sendReliable({type:'add',stroke:payload});
-      requestRender(); debounceSave();
-    };
-    img.src=ev.target.result;
-  };
-  reader.readAsDataURL(file);
+  if(file) await importPNG(file);
   e.target.value='';
 };
+document.addEventListener('paste', e=>{
+  const item=[...(e.clipboardData?.items||[])].find(it=>it.type==='image/png');
+  if(item){ const file=item.getAsFile(); if(file) importPNG(file); }
+});
+cvs.addEventListener('dragover', e=>{ e.preventDefault(); });
+cvs.addEventListener('drop', e=>{
+  e.preventDefault();
+  const file=e.dataTransfer.files[0];
+  if(file) importPNG(file);
+});
 
 document.addEventListener('keydown',e=>{
   if(e.target.tagName==='INPUT') return;
@@ -602,14 +599,22 @@ function handleMsg(op){
 }
 
 function serializeState(){ return { bg: bgColor, strokes: Array.from(strokes.values()) }; }
-function mergeState(state){
+function mergeState(state, opt={}){
+  const added=[]; const setBg = opt.setBg!==false;
   try{
-    if (state.bg) bgColor = state.bg;
+    if (setBg && state.bg) bgColor = state.bg;
     if (Array.isArray(state.strokes)){
-      for(const s of state.strokes){ if(!strokes.has(s.id)){ if(s.mode==='image') loadImageForStroke(s); strokes.set(s.id, s); cache.set(s.id, s); } }
+      for(const s of state.strokes){
+        const ex = strokes.get(s.id);
+        if(!ex || (ex.points && s.points && s.points.length>ex.points.length)){
+          if(s.mode==='image') loadImageForStroke(s);
+          strokes.set(s.id, s); cache.set(s.id, s); added.push(s.id);
+        }
+      }
     }
     requestRender(); debounceSave();
   }catch{}
+  return added;
 }
 
 // undo/redo
@@ -617,25 +622,14 @@ function undo(){ const id = myStack.pop(); if(!id) return; Net.sendReliable({typ
 function redo(){ const id = redoStack.pop(); if(!id) return; const s = cache.get(id); if(!s) return; strokes.set(id, s); const payload={...s}; Net.sendReliable({type:'add', stroke:payload}); myStack.push(id); requestRender(); debounceSave(); }
 
 // PNG экспорт
-function exportPNG(){
+async function exportPNG(){
   if (strokes.size===0){ alert('Нечего сохранять'); return; }
-  const bb = bboxOfStrokes(); if(!bb){ alert('Нечего сохранять'); return; }
-  const MAX=8192; const width=Math.ceil(bb.maxX-bb.minX), height=Math.ceil(bb.maxY-bb.minY);
-  const scale=Math.min(MAX/width, MAX/height, 1);
-  const off=document.createElement('canvas'); off.width=Math.max(1,Math.floor(width*scale)); off.height=Math.max(1,Math.floor(height*scale));
-  const ox=off.getContext('2d'); ox.fillStyle=bgColor; ox.fillRect(0,0,off.width,off.height);
-  for(const s of strokes.values()){
-    if(s.mode==='image'){
-      if(s._img) ox.drawImage(s._img,(s.x-bb.minX)*scale,(s.y-bb.minY)*scale,s.w*scale,s.h*scale);
-      continue;
-    }
-    ox.save(); ox.globalCompositeOperation=(s.mode==='erase')?'destination-out':'source-over';
-    ox.strokeStyle=s.color; ox.lineJoin='round'; ox.lineCap='round'; ox.lineWidth=s.size*scale;
-    ox.beginPath(); s.points.forEach((p,i)=>{ const x=(p.x-bb.minX)*scale, y=(p.y-bb.minY)*scale; if(i===0) ox.moveTo(x,y); else ox.lineTo(x,y); }); ox.stroke(); ox.restore();
-  }
-  off.toBlob(b=>{ const a=document.createElement('a'); a.href=URL.createObjectURL(b); a.download='canvas.png'; a.click(); }, 'image/png');
+  const blob=await exportEmbeddedPNG();
+  const a=document.createElement('a');
+  a.href=URL.createObjectURL(blob);
+  a.download='canvas.png';
+  a.click();
 }
-function bboxOfStrokes(){ let minX=Infinity,minY=Infinity,maxX=-Infinity,maxY=-Infinity, any=false; for(const s of strokes.values()){ const b=bboxOfStroke(s); if(b){ any=true; if(b.x<minX)minX=b.x; if(b.y<minY)minY=b.y; if(b.x+b.w>maxX)maxX=b.x+b.w; if(b.y+b.h>maxY)maxY=b.y+b.h; } } return any?{minX,minY,maxX,maxY}:null; }
 
 // локальная персистенция + серверная
 function saveLocal(){ try{ localStorage.setItem('room:'+roomId, JSON.stringify(serializeState())); }catch{} }


### PR DESCRIPTION
## Summary
- export canvas to PNG with transparent background and embedded `rtcanvas` state metadata
- add import workflow that restores from metadata or vectorizes regular PNG with placement UI
- support drag & drop, paste, and new Import button

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6899c6cef8f483329bc5ee2480e57c36