### PR TITLE
feat: add raster PNG import with pixel strokes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -348,10 +348,11 @@
   <div class="row"><button id="settingsClose">Закрыть</button></div>
 </div>
 
+<script type="module" src="raster-import.js"></script>
 <script type="module" src="embed-png.js"></script>
 <script src="net-webrtc.js"></script>
 <script type="module">
-  import { exportEmbeddedPNG, importPNG } from "./embed-png.js";
+  import { exportEmbeddedPNG } from "./embed-png.js";
   // ===== util =====
   const $ = (s) => document.querySelector(s);
   const $$ = (s) => Array.from(document.querySelectorAll(s));
@@ -419,6 +420,7 @@
     selOp = null,
     selectionPreview = null;
   let cursorColor = "#007aff";
+  window.importActive = false;
   const defaultHotkeys = {
     draw: "1",
     erase: "2",
@@ -455,7 +457,7 @@
   loadSettings();
   function renderHint() {
     $("#hint").textContent =
-      `Кисть: ${hotkeys.draw} • Ластик: ${hotkeys.erase} • Выделение: ${hotkeys.select} • Заливка: ${hotkeys.fill} • Размер: ${hotkeys.size2}/${hotkeys.size6}/${hotkeys.size12}/${hotkeys.size24} • Колёсико: зум • Shift+колёсико: панорама • Средняя кнопка: перетаскивание`;
+      `Кисть: ${hotkeys.draw} • Ластик: ${hotkeys.erase} • Выделение: ${hotkeys.select} • Заливка: ${hotkeys.fill} • Размер: ${hotkeys.size2}/${hotkeys.size6}/${hotkeys.size12}/${hotkeys.size24} • Колёсико: зум • Shift+колёсико: панорама • Shift при импорте: фиксирует пропорции • Средняя кнопка: перетаскивание`;
   }
   renderHint();
 
@@ -463,6 +465,7 @@
   const cache = new Map(); // полный штрих (для redo/ресинка)
   const myStack = []; // ids моих штрихов (для undo)
   const redoStack = []; // ids для redo
+  const rasterDirty = new Set();
 
   const patternCanvas = document.createElement("canvas");
   patternCanvas.width = 8;
@@ -575,16 +578,16 @@
   };
   imageLoader.onchange = async (e) => {
     const file = e.target.files[0];
-    if (file) await importPNG(file);
+    if (file) await window.beginImport(file);
     e.target.value = "";
   };
   document.addEventListener("paste", async (e) => {
     const item = [...(e.clipboardData?.items || [])].find(
-      (it) => it.type === "image/png",
+      (it) => it.type.startsWith("image/"),
     );
     if (item) {
       const file = item.getAsFile();
-      if (file) await importPNG(file);
+      if (file) await window.beginImport(file);
     }
   });
   cvs.addEventListener("dragover", (e) => {
@@ -593,7 +596,7 @@
   cvs.addEventListener("drop", async (e) => {
     e.preventDefault();
     const file = e.dataTransfer.files[0];
-    if (file) await importPNG(file);
+    if (file) await window.beginImport(file);
   });
   window.addEventListener("dragover", (e) => {
     e.preventDefault();
@@ -601,10 +604,11 @@
   window.addEventListener("drop", async (e) => {
     e.preventDefault();
     const f = e.dataTransfer.files[0];
-    if (f) await importPNG(f);
+    if (f) await window.beginImport(f);
   });
 
   document.addEventListener("keydown", (e) => {
+    if (window.importActive) return;
     if (e.target.tagName === "INPUT") return;
     const k = e.key;
     if (k === hotkeys.draw) setTool("draw");
@@ -923,12 +927,18 @@
         for (const id of selection.ids) {
           const o = selOp.orig.get(id);
           const s = strokes.get(id);
-          if (s.mode === "fill") {
-            s.points[0].x = o.points[0].x + dx;
-            s.points[0].y = o.points[0].y + dy;
-          } else if (s.mode === "image") {
+          if (s.mode === "image") {
             s.x = o.x + dx;
             s.y = o.y + dy;
+          } else if (s.mode === "raster") {
+            s.runs = o.runs.map((r) => {
+              const y = Math.round(r.y + dy);
+              const x0 = Math.round(r.x0 + dx);
+              const x1 = Math.round(r.x1 + dx);
+              return { y, x0, x1, color: r.color };
+            });
+            s.rowH = o.rowH ?? 1;
+            updateRasterBBox(s);
           } else {
             s.points = o.points.map((p) => ({ x: p.x + dx, y: p.y + dy }));
           }
@@ -951,8 +961,8 @@
           h: Math.abs(y2 - y1),
         };
         selection.rect = rect;
-        const sx = rect.w / r.w,
-          sy = rect.h / r.h;
+        const sx = r.w ? rect.w / r.w : 1,
+          sy = r.h ? rect.h / r.h : 1;
         const ox = r.x,
           oy = r.y;
         selection.path = selOp.path.map((p) => ({
@@ -962,15 +972,20 @@
         for (const id of selection.ids) {
           const o = selOp.orig.get(id);
           const s = strokes.get(id);
-          if (s.mode === "fill") {
-            const p = o.points[0];
-            s.points[0].x = rect.x + (p.x - ox) * sx;
-            s.points[0].y = rect.y + (p.y - oy) * sy;
-          } else if (s.mode === "image") {
+          if (s.mode === "image") {
             s.x = rect.x + (o.x - ox) * sx;
             s.y = rect.y + (o.y - oy) * sy;
             s.w = o.w * sx;
             s.h = o.h * sy;
+          } else if (s.mode === "raster") {
+            s.runs = o.runs.map((r) => {
+              const y = Math.round(rect.y + (r.y - oy) * sy);
+              const x0 = Math.round(rect.x + (r.x0 - ox) * sx);
+              const x1 = Math.round(rect.x + (r.x1 - ox) * sx);
+              return { y, x0, x1, color: r.color };
+            });
+            s.rowH = (o.rowH ?? 1) * sy;
+            updateRasterBBox(s);
           } else {
             s.points = o.points.map((p) => ({
               x: rect.x + (p.x - ox) * sx,
@@ -995,6 +1010,23 @@
         points: [w],
       });
       requestRender();
+    }
+    if (mode === "erase" && isDown) {
+      const rad = brush.size / 2;
+      let changed = false;
+      for (const [id, s] of strokes) {
+        if (s === current) continue;
+        if (s.mode === "raster") {
+          if (!s._bbox) updateRasterBBox(s);
+          if (!circleIntersectsBBox(w.x, w.y, rad, s._bbox)) continue;
+          eraseRasterStroke(s, w.x, w.y, rad);
+          rasterDirty.add(s.id);
+          changed = true;
+        }
+      }
+      if (changed) {
+        requestRender();
+      }
     }
     Net.sendCursor({ x: w.x, y: w.y, drawing: isDown });
   });
@@ -1027,6 +1059,7 @@
             const s = strokes.get(id);
             Net.sendReliable({ type: "del", id });
             const payload = { ...s };
+            if (payload._bbox) delete payload._bbox;
             Net.sendReliable({ type: "add", stroke: payload });
           }
       }
@@ -1038,6 +1071,25 @@
       return;
     }
     current = null;
+    if (rasterDirty.size) {
+      const ops = [];
+      for (const id of rasterDirty) {
+        const s = strokes.get(id);
+        if (!s) continue;
+        compactRuns(s);
+        ops.push({ type: "del", id });
+        if (s.runs.length) {
+          const payload = { ...s };
+          if (payload._bbox) delete payload._bbox;
+          ops.push({ type: "add", stroke: payload });
+        } else {
+          strokes.delete(id);
+        }
+      }
+      Net.sendReliable({ type: "batch", ops });
+      rasterDirty.clear();
+      debounceSave();
+    }
   });
 
   cvs.addEventListener("pointercancel", (e) => {
@@ -1071,6 +1123,7 @@
   );
 
   addEventListener("keydown", (e) => {
+    if (window.importActive) return;
     if (e.key === "Delete" && selection) {
       for (const id of selection.ids) {
         strokes.delete(id);
@@ -1148,6 +1201,40 @@
     }
     return inside;
   }
+  function polyIntersectsRect(poly, rx, ry, rw, rh) {
+    const pb = bboxOfPoints(poly);
+    if (pb.x > rx + rw || pb.x + pb.w < rx || pb.y > ry + rh || pb.y + pb.h < ry)
+      return false;
+    const rectPts = [
+      { x: rx, y: ry },
+      { x: rx + rw, y: ry },
+      { x: rx, y: ry + rh },
+      { x: rx + rw, y: ry + rh },
+    ];
+    if (rectPts.some((p) => pointInPoly(p, poly))) return true;
+    const inRect = (p) => p.x >= rx && p.x <= rx + rw && p.y >= ry && p.y <= ry + rh;
+    if (poly.some(inRect)) return true;
+    const segInt = (a, b, c, d) => {
+      const s1x = b.x - a.x,
+        s1y = b.y - a.y,
+        s2x = d.x - c.x,
+        s2y = d.y - c.y;
+      const s = (-s1y * (a.x - c.x) + s1x * (a.y - c.y)) / (-s2x * s1y + s1x * s2y);
+      const t = (s2x * (a.y - c.y) - s2y * (a.x - c.x)) / (-s2x * s1y + s1x * s2y);
+      return s >= 0 && s <= 1 && t >= 0 && t <= 1;
+    };
+    const rectEdges = [
+      [rectPts[0], rectPts[1]],
+      [rectPts[1], rectPts[3]],
+      [rectPts[3], rectPts[2]],
+      [rectPts[2], rectPts[0]],
+    ];
+    for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+      const e1 = [poly[j], poly[i]];
+      if (rectEdges.some((e2) => segInt(e1[0], e1[1], e2[0], e2[1]))) return true;
+    }
+    return false;
+  }
   function strokeIntersectsPoly(s, poly) {
     if (s.mode === "image") {
       const pts = [
@@ -1158,23 +1245,29 @@
       ];
       return pts.some((pt) => pointInPoly(pt, poly));
     }
-    if (s.mode === "fill") {
-      return pointInPoly(s.points[0], poly);
+    if (s.mode === "raster") {
+      if (!s.runs.length) return false;
+      if (!s._bbox) updateRasterBBox(s);
+      const { x, y, w, h } = s._bbox;
+      return polyIntersectsRect(poly, x, y, w, h);
     }
     return s.points.some((pt) => pointInPoly(pt, poly));
   }
   function cloneStroke(s) {
-    return s.mode === "image"
-      ? { ...s }
-      : { ...s, points: s.points.map((p) => ({ ...p })) };
+    if (s.mode === "image") return { ...s };
+    if (s.mode === "raster")
+      return { ...s, runs: s.runs.map((r) => ({ ...r })) };
+    return { ...s, points: s.points.map((p) => ({ ...p })) };
   }
   function bboxOfStroke(s) {
-    if (s.mode === "fill") {
-      const p = s.points[0];
-      return { x: p.x - 1, y: p.y - 1, w: 2, h: 2 };
-    }
     if (s.mode === "image") {
       return { x: s.x, y: s.y, w: s.w, h: s.h };
+    }
+    if (s.mode === "raster") {
+      if (s._bbox) return { ...s._bbox };
+      if (!s.runs.length) return { x: 0, y: 0, w: 0, h: 0 };
+      updateRasterBBox(s);
+      return { ...s._bbox };
     }
     let minX = Infinity,
       minY = Infinity,
@@ -1192,102 +1285,75 @@
     const n = parseInt(hex.slice(1), 16);
     return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
   }
-  function applyFillStroke(s) {
-    const w = cvs.width,
-      h = cvs.height;
-    const x = Math.round((s.points[0].x - camera.x) * camera.scale * DPR);
-    const y = Math.round((s.points[0].y - camera.y) * camera.scale * DPR);
-    if (x < 0 || y < 0 || x >= w || y >= h) return;
-    const img = ctx.getImageData(0, 0, w, h);
-    const data = img.data;
-    const idx = (y * w + x) * 4;
-    const target = [data[idx], data[idx + 1], data[idx + 2], data[idx + 3]];
-    const fill = hexToRgb(s.color);
-    if (
-      target[0] === fill[0] &&
-      target[1] === fill[1] &&
-      target[2] === fill[2] &&
-      target[3] === 255
-    )
-      return;
-    const stack = [[x, y]];
-    const match = (i) =>
-      data[i] === target[0] &&
-      data[i + 1] === target[1] &&
-      data[i + 2] === target[2] &&
-      data[i + 3] === target[3];
-    while (stack.length) {
-      const [cx, cy] = stack.pop();
-      const i = (cy * w + cx) * 4;
-      if (!match(i)) continue;
-      data[i] = fill[0];
-      data[i + 1] = fill[1];
-      data[i + 2] = fill[2];
-      data[i + 3] = 255;
-      if (cx > 0) stack.push([cx - 1, cy]);
-      if (cx < w - 1) stack.push([cx + 1, cy]);
-      if (cy > 0) stack.push([cx, cy - 1]);
-      if (cy < h - 1) stack.push([cx, cy + 1]);
+
+  function eraseRasterStroke(s, cx, cy, rad) {
+    const out = [];
+    const r2 = rad * rad;
+    const rh = s.rowH ?? 1;
+    for (const run of s.runs) {
+      const top = run.y;
+      const bottom = run.y + rh;
+      let dy = 0;
+      if (cy < top) dy = top - cy;
+      else if (cy > bottom) dy = cy - bottom;
+      if (dy > rad) {
+        out.push(run);
+        continue;
+      }
+      const dx = Math.sqrt(r2 - dy * dy);
+      const cutL = Math.floor(cx - dx);
+      const cutR = Math.ceil(cx + dx);
+      if (run.x1 < cutL || run.x0 > cutR) {
+        out.push(run);
+        continue;
+      }
+      if (run.x0 < cutL) {
+        const l = { y: run.y, x0: run.x0, x1: cutL - 1, color: run.color };
+        if (l.x0 <= l.x1) out.push(l);
+      }
+      if (run.x1 > cutR) {
+        const r = { y: run.y, x0: cutR + 1, x1: run.x1, color: run.color };
+        if (r.x0 <= r.x1) out.push(r);
+      }
     }
-    ctx.putImageData(img, 0, 0);
+    s.runs = out;
   }
 
-  function rasterToStrokes(imgCanvas) {
-    const { width, height } = imgCanvas;
-    const ix = imgCanvas.getContext("2d").getImageData(0, 0, width, height);
-    const data = ix.data;
-    const quant = (v) => ((v / 16) | 0) * 16;
-    const out = [];
-    const MAX = 50000;
-    let stepY = 2;
-    let idn = 0;
-    while (true) {
-      out.length = 0;
-      const lineSize = (stepY + 1) / (camera.scale * DPR);
-      for (let y = 0; y < height; y += stepY) {
-        let x = 0;
-        while (x < width) {
-          const i = (y * width + x) * 4;
-          const a = data[i + 3];
-          if (a < 8) {
-            x++;
-            continue;
-          }
-          const r = quant(data[i]),
-            g = quant(data[i + 1]),
-            b = quant(data[i + 2]);
-          let x0 = x,
-            x1 = x;
-          for (let xx = x + 1; xx < width; xx++) {
-            const j = (y * width + xx) * 4;
-            const aa = data[j + 3];
-            const rr = quant(data[j]),
-              gg = quant(data[j + 1]),
-              bb = quant(data[j + 2]);
-            if (aa < 8 || rr !== r || gg !== g || bb !== b) break;
-            x1 = xx;
-          }
-          if (x1 > x0) {
-            const p0 = screenToWorld(x0 / DPR, y / DPR);
-            const p1 = screenToWorld(x1 / DPR, y / DPR);
-            out.push({
-              id: `fill-${Date.now()}-${idn++}`,
-              by: meId,
-              mode: "draw",
-              color: `rgb(${r},${g},${b})`,
-              size: lineSize,
-              points: [p0, p1],
-            });
-            if (out.length > MAX) break;
-          }
-          x = x1 + 1;
-        }
-        if (out.length > MAX) break;
-      }
-      if (out.length <= MAX || stepY > 16) break;
-      stepY *= 2;
+  function updateRasterBBox(s) {
+    const rh = s.rowH ?? 1;
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
+    for (const r of s.runs) {
+      if (r.x0 < minX) minX = r.x0;
+      if (r.y < minY) minY = r.y;
+      if (r.x1 > maxX) maxX = r.x1;
+      if (r.y + rh > maxY) maxY = r.y + rh;
     }
-    return out;
+    s._bbox =
+      minX === Infinity
+        ? { x: 0, y: 0, w: 0, h: 0 }
+        : { x: minX, y: minY, w: maxX - minX + 1, h: maxY - minY };
+  }
+
+  function circleIntersectsBBox(cx, cy, r, b) {
+    const dx = Math.max(b.x - cx, 0, cx - (b.x + b.w));
+    const dy = Math.max(b.y - cy, 0, cy - (b.y + b.h));
+    return dx * dx + dy * dy <= r * r;
+  }
+
+  function compactRuns(s) {
+    s.runs.sort((a, b) => a.y - b.y || a.x0 - b.x0);
+    const out = [];
+    for (const r of s.runs) {
+      const last = out[out.length - 1];
+      if (last && last.y === r.y && last.color === r.color && last.x1 >= r.x0 - 1) {
+        if (r.x1 > last.x1) last.x1 = r.x1;
+      } else out.push(r);
+    }
+    s.runs = out;
+    updateRasterBBox(s);
   }
 
   function performFill(w) {
@@ -1352,12 +1418,16 @@
       }
     }
     ox.putImageData(outImg, 0, 0);
-    const strokesVec = rasterToStrokes(off);
-    mergeState({ strokes: strokesVec });
-    for (const s of strokesVec) {
-      myStack.push(s.id);
-      Net.sendReliable({ type: "add", stroke: { ...s } });
-    }
+    const stroke = window.vectorizeToRasterRuns(off, {
+      x: camera.x,
+      y: camera.y,
+      scale: 1 / (camera.scale * DPR),
+    });
+    mergeState({ strokes: [stroke] });
+    myStack.push(stroke.id);
+    const payload = { ...stroke };
+    if (payload._bbox) delete payload._bbox;
+    Net.sendReliable({ type: "add", stroke: payload });
     requestRender();
     debounceSave();
   }
@@ -1399,16 +1469,14 @@
   }
   loop();
   function draw() {
-    const w = cvs.width / DPR,
-      h = cvs.height / DPR;
-    ctx.clearRect(0, 0, w, h);
+    const vw = cvs.width / DPR,
+      vh = cvs.height / DPR;
+    ctx.clearRect(0, 0, vw, vh);
     for (const s of strokes.values()) {
-      if (s.mode === "fill") {
-        applyFillStroke(s);
-        continue;
-      }
       if (s.mode === "image") {
-        if (s._img)
+        if (s._img) {
+          const prevSmooth = ctx.imageSmoothingEnabled;
+          ctx.imageSmoothingEnabled = false;
           ctx.drawImage(
             s._img,
             (s.x - camera.x) * camera.scale,
@@ -1416,6 +1484,36 @@
             s.w * camera.scale,
             s.h * camera.scale,
           );
+          ctx.imageSmoothingEnabled = prevSmooth;
+        }
+        continue;
+      }
+      if (s.mode === "raster") {
+        if (!s._bbox) updateRasterBBox(s);
+        const scale = camera.scale;
+        const vx1 = vw,
+          vy1 = vh;
+        const bx0 = (s._bbox.x - camera.x) * scale;
+        const by0 = (s._bbox.y - camera.y) * scale;
+        const bx1 = (s._bbox.x + s._bbox.w - camera.x) * scale;
+        const by1 = (s._bbox.y + s._bbox.h - camera.y) * scale;
+        if (bx1 < 0 || bx0 > vx1 || by1 < 0 || by0 > vy1) continue;
+        let last = "";
+        for (const r of s.runs) {
+          if (r.color !== last) {
+            ctx.fillStyle = r.color;
+            last = r.color;
+          }
+          // левая/верхняя границы — floor; правая/нижняя — ceil с учётом включительного конца
+          const x0p = Math.floor((r.x0 - camera.x) * scale);
+          const x1p = Math.ceil((r.x1 + 1 - camera.x) * scale);
+          const y0p = Math.floor((r.y - camera.y) * scale);
+          const y1p = Math.ceil((r.y + (s.rowH ?? 1) - camera.y) * scale);
+          if (x1p < 0 || x0p > vx1 || y1p < 0 || y0p > vy1) continue;
+          const rw = Math.max(1, x1p - x0p);
+          const rh = Math.max(1, y1p - y0p);
+          ctx.fillRect(x0p, y0p, rw, rh);
+        }
         continue;
       }
       ctx.save();
@@ -1605,8 +1703,15 @@
   }
 
   function serializeState() {
+    const out = [];
+    for (const s of strokes.values()) {
+      const copy = { ...s };
+      delete copy._bbox;
+      delete copy._img;
+      out.push(copy);
+    }
     // ВАЖНО: не инкрементим здесь — просто возвращаем текущее
-    return { bg: bgColor, strokes: Array.from(strokes.values()), rev };
+    return { bg: bgColor, strokes: out, rev };
   }
   function mergeState(state, opt = {}) {
     try {
@@ -1618,13 +1723,28 @@
       }
       if (state && Array.isArray(state.strokes)) {
         for (const s of state.strokes) {
+          if (s.mode === "raster") compactRuns(s);
           const had = strokes.get(s.id);
           if (!had) {
             if (s.mode === "image") loadImageForStroke(s);
             strokes.set(s.id, s);
             cache.set(s.id, s);
             changed = true;
-          } else if ((had.points?.length || 0) < (s.points?.length || 0)) {
+          } else if (
+            s.mode === "image" ||
+            s.mode === "raster" ||
+            (had.points?.length || 0) < (s.points?.length || 0)
+          ) {
+            if (s.mode === "image" && had.mode === "image") {
+              const sigHad = `${had.w}x${had.h}:${had.src?.length || 0}`;
+              const sigNew = `${s.w}x${s.h}:${s.src?.length || 0}`;
+              if (sigHad === sigNew) continue;
+            }
+            if (s.mode === "raster" && had.mode === "raster") {
+              const sigHad = `${had.runs.length}:${had.rowH ?? 1}`;
+              const sigNew = `${s.runs.length}:${s.rowH ?? 1}`;
+              if (sigHad === sigNew) continue;
+            }
             if (s.mode === "image") loadImageForStroke(s);
             strokes.set(s.id, s);
             cache.set(s.id, s);
@@ -1660,6 +1780,8 @@
     mergeState,
     screenToWorld,
     requestRender,
+    debounceSave,
+    genId,
   });
 
   // undo/redo
@@ -1679,6 +1801,7 @@
     if (!s) return;
     strokes.set(id, s);
     const payload = { ...s };
+    if (payload._bbox) delete payload._bbox;
     Net.sendReliable({ type: "add", stroke: payload });
     myStack.push(id);
     requestRender();

--- a/public/raster-import.js
+++ b/public/raster-import.js
@@ -1,0 +1,425 @@
+import extract from "https://esm.sh/png-chunks-extract";
+import { inflate } from "https://esm.sh/pako@2.1.0";
+
+function findITXtRt(pngUint8) {
+  const chunks = extract(pngUint8);
+  for (const c of chunks) if (c.name === "iTXt") {
+    const d = c.data;
+    let i = 0;
+    while (i < d.length && d[i] !== 0) i++;
+    const kw = new TextDecoder().decode(d.slice(0, i));
+    if (kw !== "rtcanvas") continue;
+    const flag = d[i + 1] | 0,
+      method = d[i + 2] | 0;
+    let j = i + 3;
+    while (j < d.length && d[j] !== 0) j++;
+    let k = j + 1;
+    while (k < d.length && d[k] !== 0) k++;
+    const payload = d.slice(k + 1);
+    const bytes = flag === 1 && method === 0 ? inflate(payload) : payload;
+    return JSON.parse(new TextDecoder().decode(bytes));
+  }
+  return null;
+}
+
+function ensureStyles() {
+  if (document.getElementById("raster-import-style")) return;
+  const style = document.createElement("style");
+  style.id = "raster-import-style";
+  style.textContent = `.import-overlay{position:absolute;inset:0;pointer-events:auto;z-index:9999;touch-action:none}
+.import-frame{position:absolute;border:2px dashed transparent;--dash:4px;background:
+  linear-gradient(#0000,#0000) padding-box,
+  repeating-linear-gradient(90deg,#7bd,#7bd var(--dash),#0000 var(--dash),#0000 calc(2*var(--dash))) border-box,
+  repeating-linear-gradient(#7bd,#7bd var(--dash),#0000 var(--dash),#0000 calc(2*var(--dash))) border-box;
+box-shadow:0 0 0 9999px rgba(0,0,0,.25);pointer-events:auto;cursor:move;touch-action:none}
+.handle{position:absolute;width:10px;height:10px;background:#7bd;border:1px solid #124;box-shadow:0 1px 2px rgba(0,0,0,.3)}
+.handle.nw{left:-6px;top:-6px;cursor:nwse-resize}
+.handle.ne{right:-6px;top:-6px;cursor:nesw-resize}
+.handle.sw{left:-6px;bottom:-6px;cursor:nesw-resize}
+.handle.se{right:-6px;bottom:-6px;cursor:nwse-resize}
+.handle.n{left:50%;top:-6px;transform:translateX(-50%);cursor:ns-resize}
+.handle.s{left:50%;bottom:-6px;transform:translateX(-50%);cursor:ns-resize}
+.handle.w{left:-6px;top:50%;transform:translateY(-50%);cursor:ew-resize}
+.handle.e{right:-6px;top:50%;transform:translateY(-50%);cursor:ew-resize}
+.sizebadge{position:absolute;right:8px;bottom:8px;background:#0b1622;color:#cfe9ff;border:1px solid #1e3a55;border-radius:6px;padding:2px 6px;font:12px/1.2 ui-monospace,monospace}
+.hint{position:absolute;left:8px;bottom:8px;background:#0b1622;color:#cfe9ff;border:1px solid #1e3a55;border-radius:6px;padding:2px 6px;font:12px/1.2 ui-monospace,monospace}
+@media (pointer:coarse){
+  .handle{width:16px;height:16px}
+  .handle.nw{left:-8px;top:-8px}
+  .handle.ne{right:-8px;top:-8px}
+  .handle.sw{left:-8px;bottom:-8px}
+  .handle.se{right:-8px;bottom:-8px}
+  .handle.n{left:50%;top:-8px;transform:translateX(-50%)}
+  .handle.s{left:50%;bottom:-8px;transform:translateX(-50%)}
+  .handle.w{left:-8px;top:50%;transform:translateY(-50%)}
+  .handle.e{right:-8px;top:50%;transform:translateY(-50%)}
+}`;
+  document.head.appendChild(style);
+}
+
+let overlay = null;
+let placement = null; // {img,state,x,y,w,h}
+
+function updateFrame() {
+  if (!placement || !overlay) return;
+  const frame = overlay.querySelector(".import-frame");
+  frame.style.left = placement.x + "px";
+  frame.style.top = placement.y + "px";
+  frame.style.width = placement.w + "px";
+  frame.style.height = placement.h + "px";
+  const badge = frame.querySelector(".sizebadge");
+  badge.textContent = `${Math.round(placement.w)}×${Math.round(placement.h)}`;
+}
+
+function cleanup() {
+  if (overlay) overlay.remove();
+  overlay = null;
+  placement = null;
+  // Keep the keydown listener; it guards on placement/importActive so it's safe
+  window.importActive = false;
+  window.requestRender && window.requestRender();
+}
+
+function keyHandler(e) {
+  if (!placement) return;
+  if (e.key === "Escape") cleanup();
+  if (e.key === "Enter") finalize();
+}
+
+document.addEventListener("keydown", keyHandler);
+
+function startOverlay(img, state) {
+  ensureStyles();
+  window.importActive = true;
+  overlay = document.createElement("div");
+  overlay.className = "import-overlay";
+  overlay.addEventListener("pointerdown", (e) => e.stopPropagation());
+  overlay.addEventListener("pointermove", (e) => e.stopPropagation(), {
+    passive: true,
+  });
+  overlay.addEventListener(
+    "wheel",
+    (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+    },
+    { passive: false },
+  );
+  const frame = document.createElement("div");
+  frame.className = "import-frame";
+  const canvas = document.createElement("canvas");
+  canvas.width = img.naturalWidth;
+  canvas.height = img.naturalHeight;
+  const ctx = canvas.getContext("2d");
+  ctx.imageSmoothingEnabled = false;
+  ctx.drawImage(img, 0, 0);
+  canvas.style.width = "100%";
+  canvas.style.height = "100%";
+  frame.appendChild(canvas);
+  const handles = ["nw","n","ne","e","se","s","sw","w"];
+  for (const h of handles) {
+    const d = document.createElement("div");
+    d.className = "handle " + h;
+    frame.appendChild(d);
+  }
+  const badge = document.createElement("div");
+  badge.className = "sizebadge";
+  frame.appendChild(badge);
+  const hint = document.createElement("div");
+  hint.className = "hint";
+  hint.textContent = "Enter — разместить, Esc — отмена, Shift — фиксировать пропорции";
+  frame.appendChild(hint);
+  overlay.appendChild(frame);
+  const stage = document.getElementById("stage");
+  stage.appendChild(overlay);
+  const vw = innerWidth,
+    vh = innerHeight;
+  let w = img.naturalWidth,
+    h = img.naturalHeight;
+  const k = Math.min(1, vw / w, vh / h);
+  w *= k;
+  h *= k;
+  placement = {
+    img: canvas,
+    state,
+    x: (vw - w) / 2,
+    y: (vh - h) / 2,
+    w,
+    h,
+    ratio: img.naturalWidth / img.naturalHeight,
+  };
+  updateFrame();
+  let action = null;
+  frame.addEventListener("pointerdown", (e) => {
+    const target = e.target;
+    const mx = e.clientX;
+    const my = e.clientY;
+    if (target.classList.contains("handle")) {
+      action = { type: "resize", dir: [...target.classList].pop(), startX: mx, startY: my, start: { ...placement } };
+    } else {
+      action = { type: "move", startX: mx, startY: my, start: { ...placement } };
+    }
+    frame.setPointerCapture(e.pointerId);
+  });
+  frame.addEventListener("pointermove", (e) => {
+    if (!action) return;
+    const dx = e.clientX - action.startX;
+    const dy = e.clientY - action.startY;
+    if (action.type === "move") {
+      placement.x = action.start.x + dx;
+      placement.y = action.start.y + dy;
+      updateFrame();
+      return;
+    }
+    let { x, y, w, h } = action.start;
+    const aspect = action.start.ratio;
+    const dir = action.dir;
+    if (dir.includes("e")) w += dx;
+    if (dir.includes("s")) h += dy;
+    if (dir.includes("w")) {
+      w -= dx;
+      x += dx;
+    }
+    if (dir.includes("n")) {
+      h -= dy;
+      y += dy;
+    }
+    if (e.shiftKey) {
+      const nw = h * aspect;
+      const nh = w / aspect;
+      if (dir === "n" || dir === "s") {
+        w = nw;
+      } else if (dir === "e" || dir === "w") {
+        h = nh;
+        if (dir === "n") y = action.start.y + action.start.h - h;
+      } else {
+        if (Math.abs(w / h - aspect) > 0.01) {
+          if (Math.abs(dx) > Math.abs(dy)) {
+            h = w / aspect;
+            if (dir.includes("n")) y = action.start.y + action.start.h - h;
+          } else {
+            w = h * aspect;
+            if (dir.includes("w")) x = action.start.x + action.start.w - w;
+          }
+        }
+      }
+    }
+    placement.x = x;
+    placement.y = y;
+    placement.w = Math.max(1, w);
+    placement.h = Math.max(1, h);
+    updateFrame();
+  });
+  frame.addEventListener("pointerup", (e) => {
+    action = null;
+    if (frame.hasPointerCapture?.(e.pointerId))
+      frame.releasePointerCapture(e.pointerId);
+  });
+  frame.addEventListener("pointercancel", (e) => {
+    action = null;
+    if (frame.hasPointerCapture?.(e.pointerId))
+      frame.releasePointerCapture(e.pointerId);
+  });
+  frame.addEventListener("wheel", (e) => {
+    e.preventDefault();
+    const ds = Math.exp(-e.deltaY / 500);
+    const cx = e.clientX;
+    const cy = e.clientY;
+    placement.w *= ds;
+    placement.h *= ds;
+    placement.x = cx - (cx - placement.x) * ds;
+    placement.y = cy - (cy - placement.y) * ds;
+    updateFrame();
+  }, {passive:false});
+}
+
+function applyTransformToState(state, tr) {
+  if (!state || !state.strokes) return;
+  for (const s of state.strokes) {
+    if (s.mode === "image") {
+      s.x = s.x * tr.scale + tr.x;
+      s.y = s.y * tr.scale + tr.y;
+      s.w *= tr.scale;
+      s.h *= tr.scale;
+    } else if (s.mode === "raster") {
+      s.runs = s.runs.map((r) => {
+        const y = Math.round(r.y * tr.scale + tr.y);
+        const x0 = Math.round(r.x0 * tr.scale + tr.x);
+        const x1 = Math.round(r.x1 * tr.scale + tr.x);
+        return { y, x0, x1, color: r.color };
+      });
+      s.rowH = (s.rowH ?? 1) * tr.scale;
+      s._bbox = computeRasterBBox(s.runs, s.rowH);
+    } else {
+      s.points = s.points.map((p) => ({
+        x: p.x * tr.scale + tr.x,
+        y: p.y * tr.scale + tr.y,
+      }));
+      s.size *= tr.scale;
+    }
+  }
+}
+function downscaleCanvas(src, factor) {
+  const w = Math.max(1, Math.round(src.width * factor));
+  const h = Math.max(1, Math.round(src.height * factor));
+  const c = document.createElement("canvas");
+  c.width = w;
+  c.height = h;
+  const x = c.getContext("2d");
+  x.imageSmoothingEnabled = false;
+  x.drawImage(src, 0, 0, w, h);
+  return c;
+}
+
+function extractRuns(src, step = 16) {
+  const { width, height } = src;
+  const ctx = src.getContext("2d");
+  const img = ctx.getImageData(0, 0, width, height);
+  const data = img.data;
+  const runs = [];
+  const quant = (v) => ((v / step) | 0) * step;
+  for (let y = 0; y < height; y++) {
+    let x = 0;
+    while (x < width) {
+      const i = (y * width + x) * 4;
+      const a = data[i + 3];
+      if (a < 8) {
+        x++;
+        continue;
+      }
+      const r = quant(data[i]);
+      const g = quant(data[i + 1]);
+      const b = quant(data[i + 2]);
+      let x0 = x,
+        x1 = x;
+      for (let xx = x + 1; xx < width; xx++) {
+        const j = (y * width + xx) * 4;
+        const aa = data[j + 3];
+        const rr = quant(data[j]);
+        const gg = quant(data[j + 1]);
+        const bb = quant(data[j + 2]);
+        if (aa < 8 || rr !== r || gg !== g || bb !== b) break;
+        x1 = xx;
+      }
+      const color = `rgb(${r},${g},${b})`;
+      runs.push({ y, x0, x1, color });
+      x = x1 + 1;
+    }
+  }
+  return runs;
+}
+
+function computeRasterBBox(runs, rowH = 1) {
+  if (!runs.length) return { x: 0, y: 0, w: 0, h: 0 };
+  let minX = Infinity,
+    minY = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity;
+  for (const r of runs) {
+    if (r.x0 < minX) minX = r.x0;
+    if (r.y < minY) minY = r.y;
+    if (r.x1 > maxX) maxX = r.x1;
+    if (r.y + rowH > maxY) maxY = r.y + rowH;
+  }
+  return { x: minX, y: minY, w: maxX - minX + 1, h: maxY - minY };
+}
+
+function vectorizeToRasterRuns(imgCanvas, worldTransform, opts = {}) {
+  const MAX_RUNS = 150000;
+  let src = imgCanvas;
+  let step = 16;
+  let runs = extractRuns(src, step);
+  while (runs.length > MAX_RUNS && (src.width > 1 || src.height > 1)) {
+    src = downscaleCanvas(src, 0.5);
+    runs = extractRuns(src, step);
+    if (runs.length > MAX_RUNS && step < 256) {
+      step *= 2;
+      runs = extractRuns(src, step);
+    }
+  }
+  const pixelScale = imgCanvas.width / src.width;
+  const outRuns = runs.map((r) => ({
+    y: Math.round(r.y * pixelScale * worldTransform.scale + worldTransform.y),
+    x0: Math.round(r.x0 * pixelScale * worldTransform.scale + worldTransform.x),
+    x1: Math.round(r.x1 * pixelScale * worldTransform.scale + worldTransform.x),
+    color: r.color,
+  }));
+  const id = window.genId?.() ??
+    `imp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const rowH = pixelScale * worldTransform.scale;
+  const stroke = {
+    id,
+    by: window.meId ?? "local",
+    mode: "raster",
+    runs: outRuns,
+    rowH,
+  };
+  stroke._bbox = computeRasterBBox(outRuns, rowH);
+  return stroke;
+}
+
+async function finalize() {
+  if (!placement) return;
+  const { img, state } = placement;
+  const worldTopLeft = window.screenToWorld(placement.x, placement.y);
+  const scale = (placement.w / img.width) / window.camera.scale;
+  if (state) {
+    applyTransformToState(state, { x: worldTopLeft.x, y: worldTopLeft.y, scale });
+    window.mergeState(state);
+    if (state.strokes)
+      for (const s of state.strokes) {
+        window.myStack.push(s.id);
+        const payload = { ...s };
+        if (payload._bbox) delete payload._bbox;
+        window.Net.sendReliable({ type: "add", stroke: payload });
+      }
+  } else {
+    const stroke = vectorizeToRasterRuns(img, {
+      x: worldTopLeft.x,
+      y: worldTopLeft.y,
+      scale,
+    });
+    window.mergeState({ strokes: [stroke] });
+    window.myStack.push(stroke.id);
+    const payload = { ...stroke };
+    delete payload._bbox;
+    window.Net.sendReliable({ type: "add", stroke: payload });
+  }
+  window.requestRender();
+  window.debounceSave && window.debounceSave();
+  cleanup();
+}
+
+export async function beginImport(fileOrBlob) {
+  if (overlay) cleanup();
+  const buf = new Uint8Array(await fileOrBlob.arrayBuffer());
+  let state = null;
+  try {
+    state = findITXtRt(buf);
+  } catch {
+    // ignore non-PNG files
+  }
+  const url = URL.createObjectURL(fileOrBlob);
+  const img = new Image();
+  try {
+    await new Promise((res, rej) => {
+      img.onload = () => {
+        URL.revokeObjectURL(url);
+        res();
+      };
+      img.onerror = () => {
+        URL.revokeObjectURL(url);
+        rej(new Error("image load failed"));
+      };
+      img.src = url;
+    });
+  } catch {
+    cleanup();
+    return;
+  }
+  startOverlay(img, state);
+}
+
+window.beginImport = beginImport;
+window.vectorizeToRasterRuns = vectorizeToRasterRuns;
+


### PR DESCRIPTION
## Summary
- refine raster selection by detecting polygon-rectangle intersections instead of relying on bbox corners
- ensure raster vectorization downscales and quantizes until run counts fit within the limit
- batch raster erasing by compacting runs only on pointerup and remove legacy per-frame fill rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a523039c88332ac5d3fdc808dd5e9