### PR TITLE
feat: brushify external PNG import

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -665,6 +665,7 @@
     const file = e.target.files[0];
     if (file) await window.beginImport(file);
     e.target.value = "";
+    e.target.blur();
   };
   document.addEventListener("paste", async (e) => {
     const item = [...(e.clipboardData?.items || [])].find(
@@ -1622,8 +1623,8 @@
         continue;
       }
       ctx.save();
-      ctx.lineJoin = "round";
-      ctx.lineCap = "round";
+      ctx.lineJoin = s.join || "round";
+      ctx.lineCap = s.cap || "round";
       setCompositeForTool(ctx, s.mode);
       ctx.strokeStyle = s.mode === "erase" ? "#000000" : s.color;
       ctx.lineWidth = s.size * camera.scale;


### PR DESCRIPTION
## Summary
- normalize embedded PNG state coordinates so overlay transforms apply correctly
- prevent Enter from retriggering import and remove placement hint overlay
- brushify external PNGs into vector strokes with stroke count limits
- round brushified stroke width to integer and size-tuned chunking for crisper pixels
- center odd-width brush strokes on half-pixels and batch network sends in chunks of 1000

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b193e0c0c8332ad58af01fcf22933