### PR TITLE
Harden production WebSocket setup

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,3 @@
 [build]
   publish = "public"
   command = ""
-
-# необязательно, но удобно — чтобы config.json всегда свежий
-[[headers]]
-  for = "/config.json"
-  [headers.values]
-    Cache-Control = "no-store, no-cache, must-revalidate, max-age=0"

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,7 @@
+/*
+  Content-Security-Policy: default-src 'self'; img-src 'self' data: blob: https:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https: wss: https://*.ngrok.io wss://*.ngrok.io https://*.ngrok-free.app wss://*.ngrok-free.app;
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff
+
+/config.json
+  Cache-Control: no-store

--- a/public/config.json
+++ b/public/config.json
@@ -1,2 +1,3 @@
-{ "SIGNAL_URL": "wss://visually-definite-frog.ngrok-free.app" }
-
+{
+  "SIGNAL_URL": "wss://visually-definite-frog.ngrok-free.app/ws"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -777,22 +777,49 @@
 
   // ===== lobby / rooms =====
   async function getSignalURL() {
-    const r = await fetch("config.json", { cache: "no-store" });
-    const j = await r.json();
-    return j.SIGNAL_URL;
+    try {
+      const r = await fetch("config.json", { cache: "no-store" });
+      if (!r.ok) throw new Error(`config.json HTTP ${r.status}`);
+      const j = await r.json();
+      console.info("[signal] config.json =", j);
+      return j.SIGNAL_URL;
+    } catch (e) {
+      console.error("[signal] failed to read config.json:", e);
+      alert("Не удалось прочитать config.json. Проверьте деплой и доступность файла.");
+      throw e;
+    }
   }
+
+  function normalizeWS(u) {
+    try {
+      const url = new URL(u, location.href);
+      if (location.protocol === "https:" && url.protocol === "ws:") {
+        url.protocol = "wss:";
+      }
+      return url.toString();
+    } catch {
+      return u;
+    }
+  }
+
   async function fetchRooms() {
     try {
-      const url = await getSignalURL();
+      const raw = await getSignalURL();
+      const url = normalizeWS(raw);
       return await new Promise((res) => {
         const ws = new WebSocket(url);
+        let opened = false;
         const t = setTimeout(() => {
           try {
             ws.close();
           } catch {}
           res([]);
         }, 2000);
-        ws.onopen = () => ws.send(JSON.stringify({ type: "list" }));
+        ws.onopen = () => {
+          opened = true;
+          console.info("[signal] WS open:", url);
+          ws.send(JSON.stringify({ type: "list" }));
+        };
         ws.onmessage = (e) => {
           const m = JSON.parse(e.data);
           if (m.type === "rooms") {
@@ -801,12 +828,20 @@
             res(m.rooms || []);
           }
         };
-        ws.onerror = () => {
+        ws.onerror = (ev) => {
+          console.error("[signal] WS error", ev);
           clearTimeout(t);
+          if (!opened) {
+            alert("Подключение к сигнал-серверу не удалось. Проверьте CSP и что URL начинается с wss://");
+          }
           res([]);
         };
+        ws.onclose = (ev) => {
+          console.warn("[signal] WS closed", ev.code, ev.reason);
+        };
       });
-    } catch {
+    } catch (e) {
+      console.error("[signal] fetchRooms failed", e);
       return [];
     }
   }
@@ -858,9 +893,23 @@
       `room-${Math.random().toString(36).slice(2, 6)}`;
     $("#room").value = rid;
     // я вешу создание на явный вызов create (реестр на сигналинге)
-    const url = await getSignalURL();
+    const url = normalizeWS(await getSignalURL());
     const ws = new WebSocket(url);
-    ws.onopen = () => ws.send(JSON.stringify({ type: "create", roomId: rid }));
+    let opened = false;
+    ws.onopen = () => {
+      opened = true;
+      console.info("[signal] WS open:", url);
+      ws.send(JSON.stringify({ type: "create", roomId: rid }));
+    };
+    ws.onerror = (ev) => {
+      console.error("[signal] WS error", ev);
+      if (!opened) {
+        alert("Подключение к сигнал-серверу не удалось. Проверьте CSP и что URL начинается с wss://");
+      }
+    };
+    ws.onclose = (ev) => {
+      console.warn("[signal] WS closed", ev.code, ev.reason);
+    };
     ws.onmessage = (e) => {
       const m = JSON.parse(e.data);
       if (m.type === "created") {
@@ -871,7 +920,7 @@
     };
   };
 
-  function joinRoom(id) {
+  async function joinRoom(id) {
     setRev(0);
     roomId = id;
     lastPull = 0;
@@ -879,6 +928,7 @@
       clearTimeout(pullTimer);
       pullTimer = null;
     }
+    const signalURL = normalizeWS(await getSignalURL());
     lobbyToStage();
     Net.connect(roomId, {
       onJoined: ({ me, roomId, peers }) => {
@@ -912,7 +962,7 @@
           latencyBadge.textContent = newText;
       },
       onClose: () => stopPing(),
-    });
+    }, signalURL);
   }
   $("#join").onclick = () => joinRoom($("#room").value.trim() || "public-room");
 

--- a/tools/protocol-smoke.mjs
+++ b/tools/protocol-smoke.mjs
@@ -6,7 +6,7 @@ async function testJoinPresence() {
   const sent = [];
   let joined = null;
   const Net = {
-    connect: (id, h) => {
+    connect: (id, h, url) => {
       joined = id;
       h.onPeerOpen("p1");
     },
@@ -16,8 +16,8 @@ async function testJoinPresence() {
   function sendPresence() {
     Net.sendReliable({ type: "presence", cursorColor });
   }
-  function joinRoom(id) {
-    Net.connect(id, { onPeerOpen: sendPresence });
+  async function joinRoom(id) {
+    Net.connect(id, { onPeerOpen: sendPresence }, "wss://test");
   }
   function renderRooms() {
     return { click: () => joinRoom("r1") };


### PR DESCRIPTION
## Summary
- enforce strict Content Security Policy and disable caching for `config.json`
- load signal server URL without cache, normalize ws:// to wss://, and log WebSocket errors
- pass normalized URL to networking layer and alert on connection failures

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b484f342083328e0c0d238f2bd81f