### PR TITLE
fix: initialize bgColor before grid draw

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -417,6 +417,8 @@
 <script type="module">
   import { exportEmbeddedPNG } from "./embed-png.js";
   let DPR = 1;
+  // ===== early app state (должно быть объявлено ДО первого resize/drawGrid) =====
+  let bgColor = "#ffffff"; // дефолт фона для drawGrid на раннем старте
   // ===== util =====
   const $ = (s) => document.querySelector(s);
   const $$ = (s) => Array.from(document.querySelectorAll(s));
@@ -512,7 +514,7 @@
   function drawGrid() {
     const w = grid.width / DPR,
       h = grid.height / DPR;
-    gtx.fillStyle = bgColor;
+    gtx.fillStyle = typeof bgColor === "string" ? bgColor : "#ffffff";
     gtx.fillRect(0, 0, w, h);
     const step = 100 * camera.scale;
     if (step > 24) {
@@ -544,7 +546,6 @@
   }
   let mode = "draw";
   let brush = { color: "#000000", size: 6 };
-  let bgColor = "#ffffff";
   let selection = null,
     selOp = null,
     selectionPreview = null;


### PR DESCRIPTION
## Summary
- initialize `bgColor` before the first resize/draw to prevent undefined access
- ensure `drawGrid` defaults to white when `bgColor` is not a string

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b86635c948332bc37b18b177bce75