### PR TITLE
Send joined message with peer list

### DIFF
--- a/public/net-webrtc.js
+++ b/public/net-webrtc.js
@@ -174,10 +174,9 @@
         return;
       }
       if (m.type === "joined") {
-        meId = m.id || meId;
-        roomId = m.roomId || roomId;
+        meId = m.id;
         log("pc", "joined", roomId, "peers", m.peers);
-        handlers.onJoined({ me: meId, roomId, peers: m.peers || [] });
+        handlers.onJoined({ me: meId, peers: m.peers || [] });
 
         // инициируем коннекты ко всем текущим пирами
         for (const pid of m.peers || []) ensurePeer(pid, /*initiator*/ true);

--- a/signal.js
+++ b/signal.js
@@ -138,11 +138,19 @@ wss.on("connection", (ws, req) => {
       peers.set(ws, meta);
       addToRoom(roomId, ws);
       log(`#${id} joined "${roomId}" (size=${rooms.get(roomId)?.size || 0})`);
+      // список пиров, уже находящихся в комнате
+      const set = rooms.get(roomId) || new Set();
+      const peerIds = [];
+      for (const client of set) {
+        if (client === ws) continue;
+        const pid = peers.get(client)?.id;
+        if (pid) peerIds.push(pid);
+      }
+      // сообщим подключившемуся его id и список пиров
+      safeSend(ws, { type: "joined", id: meta.id, peers: peerIds });
       // отдадим состояние, если есть
       const st = roomState.get(roomId);
       if (st) safeSend(ws, { type: "state_full", state: st });
-      // уведомление о пирах (минимально)
-      safeSend(ws, { type: "peers", room: roomId, count: rooms.get(roomId)?.size || 1 });
       return;
     }
 


### PR DESCRIPTION
## Summary
- Notify new clients of their ID and existing peers via a `joined` message
- Handle `joined` messages on the client to set `meId`, fire `onJoined`, and connect to listed peers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e1b68bc988332825acc8d5691cd14